### PR TITLE
Wait for tx in api hooks

### DIFF
--- a/lib/hooks/api.ts
+++ b/lib/hooks/api.ts
@@ -31,7 +31,7 @@ import {
   WithTxDigest,
   ownerAddress,
 } from "../shared/sui";
-import { suiObjectQueryKey, suiOwnedObjectsQueryKey } from "./sui";
+import { sui, suiObjectQueryKey, suiOwnedObjectsQueryKey } from "./sui";
 
 export function useNewMintTicket(): UseMutationResult<
   MintTicket & WithOwner & WithTxDigest,
@@ -44,7 +44,9 @@ export function useNewMintTicket(): UseMutationResult<
       uri: () => "/api/heroes/new_mint_ticket",
       resultSchema: intersection([WithMintTicket, WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res) => {
+    onSuccess: async (res) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, MINT_TICKET_MOVE_TYPE],
@@ -67,7 +69,9 @@ export function useMintHero(): UseMutationResult<
       baseUri: () => "/api/heroes/mint",
       resultSchema: intersection([WithHero, WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res, { ticketId }) => {
+    onSuccess: async (res, { ticketId }) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, HERO_MOVE_TYPE],
@@ -97,7 +101,9 @@ export function useNewLevelUpTicket(): UseMutationResult<
       body: () => undefined,
       resultSchema: intersection([WithLevelUpTicket, WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res) => {
+    onSuccess: async (res) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [
@@ -125,7 +131,9 @@ export function useLevelUpHero(): UseMutationResult<
       body: ({ heroId, keyPair, ...req }) => req,
       resultSchema: intersection([WithHero, WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res, { ticketId }) => {
+    onSuccess: async (res, { ticketId }) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, HERO_MOVE_TYPE],
@@ -162,7 +170,9 @@ export function useBurnHero(): UseMutationResult<
       body: () => undefined,
       resultSchema: intersection([WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res, { heroId }) => {
+    onSuccess: async (res, { heroId }) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, HERO_MOVE_TYPE],
@@ -189,7 +199,9 @@ export function useSendHero(): UseMutationResult<
       body: ({ heroId, keyPair, ...req }) => req,
       resultSchema: intersection([WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res, { heroId }) => {
+    onSuccess: async (res, { heroId }) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, HERO_MOVE_TYPE],
@@ -216,7 +228,9 @@ export function useUpdateHero(): UseMutationResult<
       body: ({ heroId, keyPair, ...req }) => req,
       resultSchema: intersection([WithHero, WithOwner, WithTxDigest]),
     }),
-    onSuccess: (res) => {
+    onSuccess: async (res) => {
+      await sui.waitForTransactionBlock({ digest: res.txDigest });
+
       const owner = ownerAddress(res.owner);
       queryClient.invalidateQueries({
         queryKey: [...suiOwnedObjectsQueryKey, owner, HERO_MOVE_TYPE],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "shinami-demo-app",
       "dependencies": {
         "@mysten/sui.js": "^0.47.0",
-        "@shinami/nextjs-zklogin": "^0.2.1",
+        "@shinami/nextjs-zklogin": "^0.2.2",
         "@tanstack/react-query": "^5.0.5",
         "@types/node": "20.3.1",
         "@types/react": "18.2.12",
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/@shinami/clients": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.7.1.tgz",
-      "integrity": "sha512-XF0SnFWvCRr+WUec2EZPC6NzIZp5wacF2ohoZTYJPfpUpTEuOUBfJZp38BvbGmVlPbNAnuZ31Z4E5r9Mwfz1PA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@shinami/clients/-/clients-0.7.2.tgz",
+      "integrity": "sha512-ekcpojxn9dUvSoffBLR3LhKZbx0z62Va0AC8xN3aFC9i45UZXeLPv3gBGONO8O1J/XqqbSZAZyhz+S6az0m7uQ==",
       "dependencies": {
         "@open-rpc/client-js": "^1.8.1",
         "superstruct": "^1.0.3"
@@ -527,12 +527,12 @@
       }
     },
     "node_modules/@shinami/nextjs-zklogin": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@shinami/nextjs-zklogin/-/nextjs-zklogin-0.2.1.tgz",
-      "integrity": "sha512-hURzT6hjfAdcELdJUoooeDMIn5Z56G7dSttfUTIjZiamxUurbkKf43onOo/FR2fCHJ8sTE6OTrb0jXeqgkclfQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@shinami/nextjs-zklogin/-/nextjs-zklogin-0.2.2.tgz",
+      "integrity": "sha512-E0Cj3+D3fX3giVW8bwprXg2vshn9ahMBAfg0pT2LsyOyChq19XL64HEUllrMIz5JGbMJI5zGlrCnLEPrsfevEQ==",
       "dependencies": {
         "@mysten/zklogin": "^0.3.6",
-        "@shinami/clients": "^0.7.1",
+        "@shinami/clients": "^0.7.2",
         "@tanstack/react-query": "^5.0.5",
         "iron-session": "^6.3.1",
         "superstruct": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@mysten/sui.js": "^0.47.0",
-    "@shinami/nextjs-zklogin": "^0.2.1",
+    "@shinami/nextjs-zklogin": "^0.2.2",
     "@tanstack/react-query": "^5.0.5",
     "@types/node": "20.3.1",
     "@types/react": "18.2.12",


### PR DESCRIPTION
This is a workaround to achieve read-after-write consitency, because the backend and frontend are using different node access keys.

[sc-2138]